### PR TITLE
Update location of APIs in Lively config file.

### DIFF
--- a/synapse/templates/default/lively-config.erb
+++ b/synapse/templates/default/lively-config.erb
@@ -1,5 +1,7 @@
 'use strict';
 
 module.exports = {
-    api : require('/vagrant/docs/config')
+    apis : {
+        api : require('/vagrant/docs/config')
+    }
 };


### PR DESCRIPTION
APIs are no longer listed at the root level, but under `apis`.

Related to synapsestudios/lively/pull/25
