### PR TITLE
Set default attribute values for mysql_charset recipe

### DIFF
--- a/roles/development.rb
+++ b/roles/development.rb
@@ -21,12 +21,7 @@ override_attributes(
 		"server_debian_password" => "synapse1",
 		"remove_anonymous_users" => true,
 		"allow_remote_root"      => true,
-		"remove_test_database"   => true,
-		"confd_dir"              => "/etc/mysql/conf.d"
-	},
-	"mysql_charset" => {
-		"encoding"  => "utf8",
-		"collation" => "utf8_unicode_ci"
+		"remove_test_database"   => true
 	},
 	"etc_environment" => {
 		"APP_ENV"  => 'development',

--- a/roles/qa.rb
+++ b/roles/qa.rb
@@ -17,12 +17,7 @@ override_attributes(
         "server_debian_password" => "synapse1",
         "remove_anonymous_users" => true,
         "allow_remote_root"      => true,
-        "remove_test_database"   => true,
-        "confd_dir"              => "/etc/mysql/conf.d"
-    },
-    "mysql_charset" => {
-        "encoding"  => "utf8",
-        "collation" => "utf8_unicode_ci"
+        "remove_test_database"   => true
     },
     "etc_environment" => {
         "APP_ENV" => 'qa'

--- a/synapse/attributes/default.rb
+++ b/synapse/attributes/default.rb
@@ -1,0 +1,3 @@
+node.default.mysql_charset.encoding  = 'utf8'
+node.default.mysql_charset.collation = 'utf8_unicode_ci'
+node.default.mysql.confd_dir         = "/etc/mysql/conf.d"


### PR DESCRIPTION
## Set default attribute values for mysql_charset recipe

That way you won't have to explicitly define values that will be the same for every project anyway.
