### PR TITLE
Restart MySQL After Making Server Public

### DIFF
--- a/synapse/recipes/dev_mysql_public.rb
+++ b/synapse/recipes/dev_mysql_public.rb
@@ -3,12 +3,5 @@ execute "make-mysql-server-public" do
     command "sed -i 's/bind-address/# bind-address/g' my.cnf"
     user 'root'
     environment ({ "HOME" => "/home/#{node['server']['user']}" })
-    notifies :reload, 'service[mysql]'
-end
-
-execute "restart-mysql-server" do
-    cwd "/etc/mysql"
-    command "service mysql restart"
-    user 'root'
-    environment ({ "HOME" => "/home/#{node['server']['user']}" })
+    notifies :restart, 'service[mysql]'
 end


### PR DESCRIPTION
## Restart MySQL After Making Server Public
### Acceptance Criteria
1. After commenting out `bind-address` in `dev_mysql_public` recipe, server should be restarted.
### Tasks
- Modify recipe
### Additional Notes
- None
